### PR TITLE
Add support for generating tables with different axes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Generated HTML files
+*.html

--- a/github-filesize.py
+++ b/github-filesize.py
@@ -73,52 +73,59 @@ g = Github(auth=auth)
 repo = g.get_repo("fontsource/font-files")
 contents = repo.get_contents("fonts/variable")
 
-font_names = [content.name for content in contents]
+font_names = [content.name for content in contents][:50]  # Limit to 50 fonts for development
 # %%
-sizes = {}
-categories = {}
-subsets = {}
-styles = {}
-variables = {}
-for font_name in font_names:
-    font = Font(repo=repo, path=f"fonts/variable/{font_name}")
-    print(font.get_family())
-    if ("latin" in font.get_subsets()) and (
-        "wght" in font.get_variables() and font.get_filesize()
-    ):
-        family = font.get_family()
-        linked_family = f'<a href="{font.get_url()}">{family}</a>'
-        sizes[linked_family] = font.get_filesize()
-        categories[linked_family] = font.get_category()
-        subsets[linked_family] = font.get_subsets()
-        styles[linked_family] = font.get_styles()
-        variables[linked_family] = font.get_variables().keys()
+def create_font_table(font_names: list[str], axis: str, output_file: str) -> None:
+    sizes = {}
+    categories = {}
+    subsets = {}
+    styles = {}
+    variables = {}
+    
+    for font_name in font_names:
+        font = Font(repo=repo, path=f"fonts/variable/{font_name}")
+        print(font.get_family())
+        if ("latin" in font.get_subsets()) and (
+            axis in font.get_variables() and font.get_filesize(variable=axis)
+        ):
+            family = font.get_family()
+            linked_family = f'<a href="{font.get_url()}">{family}</a>'
+            sizes[linked_family] = font.get_filesize(variable=axis)
+            categories[linked_family] = font.get_category()
+            subsets[linked_family] = font.get_subsets()
+            styles[linked_family] = font.get_styles()
+            variables[linked_family] = font.get_variables().keys()
 
-# %%
-df = pd.DataFrame.from_dict(
-    {
-        "Latin file size [bytes]": sizes,
-        "Category": categories,
-        "Subsets": subsets,
-        "Style": styles,
-        "Variables": variables,
-    }
-)
-# %%
-html = to_html_datatable(
-    df.sort_values("Latin file size [bytes]"),
-    display_logo_when_loading=False,
-    layout={
-        "topStart": "search",
-        "topEnd": "pageLength",
-        "bottomStart": "paging",
-        "bottomEnd": "info",
-    },
-    column_filters="footer",
-    lengthMenu=[10, 25, 50, 100, 250, 500],
-)
+    df = pd.DataFrame.from_dict(
+        {
+            f"Latin file size [{axis}] [bytes]": sizes,
+            "Category": categories,
+            "Subsets": subsets,
+            "Style": styles,
+            "Variables": variables,
+        }
+    )
 
-with open("index.html", "w") as table:
-    table.write(HTML(html).data)
+    html = to_html_datatable(
+        df.sort_values(f"Latin file size [{axis}] [bytes]"),
+        display_logo_when_loading=False,
+        layout={
+            "topStart": "search",
+            "topEnd": "pageLength",
+            "bottomStart": "paging",
+            "bottomEnd": "info",
+        },
+        column_filters="footer",
+        lengthMenu=[10, 25, 50, 100, 250, 500],
+    )
+
+    with open(output_file, "w") as table:
+        table.write(HTML(html).data)
+
+# Create table for wght axis
+create_font_table(font_names, "wght", "index.html")
+
+# Create table for opsz axis
+create_font_table(font_names, "opsz", "opsz.html")
 
 # %%

--- a/github-filesize.py
+++ b/github-filesize.py
@@ -73,7 +73,11 @@ g = Github(auth=auth)
 repo = g.get_repo("fontsource/font-files")
 contents = repo.get_contents("fonts/variable")
 
-font_names = [content.name for content in contents][:50]  # Limit to 50 fonts for development
+font_names = [content.name for content in contents][
+    :50
+]  # Limit to 50 fonts for development
+
+
 # %%
 def create_font_table(font_names: list[str], axis: str, output_file: str) -> None:
     sizes = {}
@@ -81,7 +85,7 @@ def create_font_table(font_names: list[str], axis: str, output_file: str) -> Non
     subsets = {}
     styles = {}
     variables = {}
-    
+
     for font_name in font_names:
         font = Font(repo=repo, path=f"fonts/variable/{font_name}")
         print(font.get_family())
@@ -121,6 +125,7 @@ def create_font_table(font_names: list[str], axis: str, output_file: str) -> Non
 
     with open(output_file, "w") as table:
         table.write(HTML(html).data)
+
 
 # Create table for wght axis
 create_font_table(font_names, "wght", "index.html")


### PR DESCRIPTION
This PR adds support for generating tables for fonts with different variable axes. Changes include:

- Created a reusable function `create_font_table` that can generate tables for any axis
- Added a table for fonts with the `opsz` axis
- Added HTML files to .gitignore to keep them out of version control
- Limited font processing to 50 fonts for development purposes