### PR TITLE
Add support for multiple variable font axes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Generated HTML files
+*.html

--- a/github-filesize.py
+++ b/github-filesize.py
@@ -127,10 +127,16 @@ def create_font_table(font_names: list[str], axis: str, output_file: str) -> Non
         table.write(HTML(html).data)
 
 
-# Create table for wght axis
-create_font_table(font_names, "wght", "index.html")
+# Create tables for different axes
+axes = {
+    "wght": "index.html",  # weight axis (default table)
+    "opsz": "opsz.html",  # optical size axis
+    "ital": "ital.html",  # italic axis
+    "wdth": "wdth.html",  # width axis
+}
 
-# Create table for opsz axis
-create_font_table(font_names, "opsz", "opsz.html")
+for axis, output_file in axes.items():
+    print(f"\nGenerating table for {axis} axis...")
+    create_font_table(font_names, axis, output_file)
 
 # %%

--- a/github-filesize.py
+++ b/github-filesize.py
@@ -128,15 +128,82 @@ def create_font_table(font_names: list[str], axis: str, output_file: str) -> Non
 
 
 # Create tables for different axes
-axes = {
-    "wght": "index.html",  # weight axis (default table)
-    "opsz": "opsz.html",  # optical size axis
-    "ital": "ital.html",  # italic axis
-    "wdth": "wdth.html",  # width axis
+axes = ["wght", "opsz", "ital", "wdth"]
+
+# Generate tables for each axis
+for axis in axes:
+    print(f"\nGenerating table for {axis} axis...")
+    create_font_table(font_names, axis, f"{axis}.html")
+
+# Create index.html with links to all tables
+index_html = """<!DOCTYPE html>
+<html>
+<head>
+    <title>Variable Font Size Tables</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            max-width: 800px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+        }
+        h1 { margin-bottom: 2rem; }
+        .axis-list {
+            list-style: none;
+            padding: 0;
+        }
+        .axis-list li {
+            margin: 1rem 0;
+        }
+        .axis-list a {
+            display: block;
+            padding: 1rem;
+            background: #f0f0f0;
+            border-radius: 0.5rem;
+            text-decoration: none;
+            color: #333;
+            font-size: 1.1rem;
+        }
+        .axis-list a:hover {
+            background: #e0e0e0;
+        }
+        .axis-name {
+            font-weight: bold;
+        }
+        .axis-desc {
+            color: #666;
+            font-size: 0.9rem;
+            margin-top: 0.3rem;
+        }
+    </style>
+</head>
+<body>
+    <h1>Variable Font Size Tables</h1>
+    <ul class="axis-list">"""
+
+# Add a link and description for each axis
+axis_descriptions = {
+    "wght": "Weight axis - controls the thickness of the font strokes",
+    "opsz": "Optical Size axis - optimizes the design for different sizes",
+    "ital": "Italic axis - controls the slant and cursive forms",
+    "wdth": "Width axis - adjusts the horizontal proportions",
 }
 
-for axis, output_file in axes.items():
-    print(f"\nGenerating table for {axis} axis...")
-    create_font_table(font_names, axis, output_file)
+for axis in axes:
+    index_html += f"""
+        <li>
+            <a href="{axis}.html">
+                <div class="axis-name">{axis.upper()} Axis</div>
+                <div class="axis-desc">{axis_descriptions[axis]}</div>
+            </a>
+        </li>"""
+
+index_html += """
+    </ul>
+</body>
+</html>"""
+
+with open("index.html", "w") as f:
+    f.write(index_html)
 
 # %%


### PR DESCRIPTION
This PR adds support for generating tables for different variable font axes. Changes include:

- Created a reusable function `create_font_table` that can generate tables for any axis
- Added tables for multiple axes:
  - `wght.html` - Weight axis table
  - `opsz.html` - Optical Size axis table
  - `ital.html` - Italic axis table
  - `wdth.html` - Width axis table
- Created a new `index.html` with:
  - Links to all axis-specific tables
  - Clear descriptions of what each axis does
  - Clean and modern styling
  - Responsive design
- Added HTML files to .gitignore to keep them out of version control
- Limited font processing to 50 fonts for development purposes